### PR TITLE
Removal of redundant cap declaration

### DIFF
--- a/detect_single_threaded.py
+++ b/detect_single_threaded.py
@@ -4,7 +4,6 @@ import tensorflow as tf
 import datetime
 import argparse
 
-cap = cv2.VideoCapture(0)
 detection_graph, sess = detector_utils.load_inference_graph()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Basically, at least on my system, the redundant declarations of cap could prevent the stream from opening correctly as the device was still being blocked by the previous cv2.VideoCapture declaration (previously on line 7), throwing:

```
VIDEOIO ERROR: V4L2: Pixel format of incoming image is unsupported by OpenCV
Unable to stop the stream: Device or resource busy
```

This commit is no logical change as the default device is still 0 as defined in the argparser.
